### PR TITLE
feat: Store user deck ids on user session and add user auth to user decks

### DIFF
--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -1,14 +1,36 @@
 import { NextFunction, Request, Response } from "express";
 import { ApiError } from "./apiError";
 
-export default function authenticate(
-  req: Request,
-  _res: Response,
-  next: NextFunction,
-) {
-  const session = req.session;
-  if (!session.userId) {
-    throw new ApiError(401, "User not authenticated.");
-  }
-  next();
+export function createAuthMiddleware(options: {
+  checkAuthentication?: boolean;
+  checkUserId?: boolean;
+  checkUserDeckId?: boolean;
+}) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const session = req.session;
+
+    if (options.checkAuthentication && !session.user) {
+      throw new ApiError(401, "User not authenticated.");
+    }
+
+    if (options.checkUserId && req.params.userId !== session.user.id) {
+      throw new ApiError(
+        403,
+        "User is not authorized to access this resource.",
+      );
+    }
+
+    if (options.checkUserDeckId) {
+      const userDeckId = req.params.deckId;
+      const isUserDeckIdValid = session.userDeckIds.includes(userDeckId);
+      if (!isUserDeckIdValid) {
+        throw new ApiError(
+          403,
+          "User is not authorized to access this resource.",
+        );
+      }
+    }
+
+    next();
+  };
 }

--- a/src/routes/lobbies.ts
+++ b/src/routes/lobbies.ts
@@ -1,14 +1,18 @@
 import { Router } from "express";
 import LobbiesController from "../controllers/lobbiesController";
-import authenticate from "../middleware/authenticate";
+import { createAuthMiddleware } from "../middleware/authenticate";
 
 export default (lobbiesController: LobbiesController) => {
   const router = Router();
 
-  router.get("/v1/lobbies/active", authenticate, async (_req, res) => {
-    const lobbies = await lobbiesController.getActiveLobbies();
-    res.status(200).json(lobbies);
-  });
+  router.get(
+    "/v1/lobbies/active",
+    createAuthMiddleware({ checkAuthentication: true }),
+    async (_req, res) => {
+      const lobbies = await lobbiesController.getActiveLobbies();
+      res.status(200).json(lobbies);
+    },
+  );
 
   return router;
 };

--- a/src/types/express-session.d.ts
+++ b/src/types/express-session.d.ts
@@ -2,10 +2,13 @@ import "express-session";
 
 declare module "express-session" {
   interface Session {
-    userId: string;
-    username: string;
-    displayName: string;
-    createdAt: Date;
-    updatedAt: Date;
+    user: {
+      id: string;
+      username: string;
+      displayName: string;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    userDeckIds: string[];
   }
 }

--- a/src/validation/userDecks.ts
+++ b/src/validation/userDecks.ts
@@ -4,6 +4,8 @@ export const createUserDeckSchema = {
   body: Joi.object({
     name: Joi.string().required(),
     description: Joi.string().optional(),
+  }),
+  params: Joi.object({
     userId: Joi.string().uuid().required(),
   }),
 };
@@ -14,31 +16,36 @@ export const updateUserDeckSchema = {
     description: Joi.string().optional(),
   }).min(1),
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
 };
 
 export const deleteUserDeckSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
 };
 
 export const getUserDeckByIdSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
 };
 
 export const getUserDeckCardsByUserDeckIdSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
 };
 
 export const createUserDeckCardSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
   body: Joi.object({
     cardId: Joi.number().required(),
@@ -48,7 +55,8 @@ export const createUserDeckCardSchema = {
 
 export const updateUserDeckCardSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
     cardId: Joi.number().required(),
   }),
   body: Joi.object({
@@ -58,14 +66,16 @@ export const updateUserDeckCardSchema = {
 
 export const deleteUserDeckCardSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
     cardId: Joi.number().required(),
   }),
 };
 
 export const saveUserDeckCardsSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
+    deckId: Joi.string().uuid().required(),
   }),
   body: Joi.object({
     cards: Joi.array()

--- a/src/validation/users.ts
+++ b/src/validation/users.ts
@@ -17,7 +17,7 @@ export const userLoginSchema = {
 
 export const updateUserSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
   }),
   body: Joi.object({
     displayName: Joi.string().optional(),
@@ -28,12 +28,12 @@ export const updateUserSchema = {
 
 export const getUserSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
   }),
 };
 
 export const deleteUserSchema = {
   params: Joi.object({
-    id: Joi.string().uuid().required(),
+    userId: Joi.string().uuid().required(),
   }),
 };

--- a/tests/util/testSetup.ts
+++ b/tests/util/testSetup.ts
@@ -39,5 +39,6 @@ export default async function setupTestEnvironment() {
   return {
     logger,
     app,
+    redisClient,
   };
 }


### PR DESCRIPTION
1. Now we will store the user deck ids on each user session
2. For user requests: verify the user is authenticated to begin with and that the user id matches
3. For user deck/user deck cards requests: verify the user is authenticated to begin with and that the user id matches AND that the userdeckid exists on the user session

Some validation checks are now implicitly verified in auth checks, so those tests were removed.